### PR TITLE
Change the matching bracket background to improve readability

### DIFF
--- a/theme.less
+++ b/theme.less
@@ -79,9 +79,10 @@
 
 .CodeMirror-matchingbracket {
   color: #a7ec21 !important;
+  background: rgba(255,255,255,0.15);
 }
 
- .CodeMirror-matchingtag {
+.CodeMirror-matchingtag {
     background: rgba(255,255,255,0.15);
 }
 


### PR DESCRIPTION
The previous implementation had unreadable matching brackets highlight. I updated it to match the "matching tag" background color.
